### PR TITLE
This adds a comma in the figures of the bar chart next to the jobacti…

### DIFF
--- a/R/viz_vicregions.R
+++ b/R/viz_vicregions.R
@@ -1552,7 +1552,7 @@ viz_reg_jobactive_vic_bar <- function(data = data_reg_jobactive_vic()) {
     ) +
     geom_text(
       nudge_y = 0.1,
-      aes(label = paste0(round2(.data$value, 0))),
+      aes(label = scales::comma(accuracy = 1, .data$value)),
       colour = "black",
       hjust = 0,
       size = 12 / .pt


### PR DESCRIPTION
This fix adds a comma in the figures of the bar chart next to the jobactive regional map. I used 'accuracy = 1' because without it, it was displaying all figures with a '.0' at the end.

0 errors v | 0 warnings v | 1 note x

R CMD check succeeded