### PR TITLE
Industries focusbox barchart fix

### DIFF
--- a/R/viz_industries.R
+++ b/R/viz_industries.R
@@ -578,37 +578,37 @@ viz_industries_emp_bysex_bar <- function(data = filter_dash_data(c(
                                            "males_rest of vic._rental, hiring and real estate services_employed part-time",
                                            "males_rest of vic._retail trade_employed part-time",
                                            "males_rest of vic._transport, postal and warehousing_employed part-time",
-                                           "males_rest of vic._wholesale trade_employed part-time",
-                                           "A84423461V",
-                                           "A84423237A"
+                                           "males_rest of vic._wholesale trade_employed part-time"
                                          ), df = dash_data) %>%
                                            dplyr::group_by(.data$series) %>%
                                            dplyr::filter(.data$date == max(.data$date)) %>%
                                            dplyr::ungroup(),
                                          chosen_industry = "Agriculture, Forestry and Fishing") {
-  df <- data %>%
+  industry_total <- data %>%
+    dplyr::group_by(.data$sex, .data$date) %>%
+    dplyr::summarise(
+      value = sum(.data$value)
+    ) %>%
     dplyr::mutate(
-      industry = dplyr::if_else(.data$industry == "",
-        "Victoria, all industries",
-        .data$industry
-      )
+      industry = "Victoria, all industries"
     )
 
-
-  df <- df %>%
-    dplyr::filter(.data$industry %in% c("Victoria, all industries", .env$chosen_industry)) %>%
+  df <- data %>%
+    dplyr::filter(.data$industry == .env$chosen_industry) %>%
     dplyr::select(
       .data$date, .data$value, .data$series,
       .data$indicator, .data$sex, .data$industry, .data$gcc_restofstate
     )
 
   df <- df %>%
-    dplyr::group_by(.data$sex, .data$industry) %>%
+    dplyr::group_by(.data$sex, .data$industry, .data$date) %>%
     dplyr::summarise(
-      value = sum(.data$value),
-      date = max(.data$date)
+      value = sum(.data$value)
     ) %>%
     dplyr::ungroup()
+
+  df <- df %>%
+    dplyr::bind_rows(industry_total)
 
   df <- df %>%
     dplyr::group_by(.data$industry) %>%


### PR DESCRIPTION
During a recent QA of an ABS data release we noticed that the function viz_industries_emp_bysex_bar() uses both quarterly and monthly data, which isn't very clean. This fix removes the monthly data set and instead calculates the industry totals from the quarterly release data.

Checklist
----

All PRs:
* [x] Rebase to latest dev branch: `git rebase -i dev`
* ~~[ ] Run [styler](https://styler.r-lib.org/) to apply consistent code formatting~~ No changes to files touched by this PR.

New/changed charts:
* [ ] Re-generate `app-cache` files by running the server and clicking to the new charts
  - [ ]  Delete old cache if modifying an existing chart (or changes won't take hold)
* [x] Menu location: Industry page
* [x] Screenshot attached 
![plot_zoom](https://user-images.githubusercontent.com/72529836/161909775-73a616eb-6663-4bfe-872e-d0b133a79139.png)
