### PR TITLE
Only salm data is unused in the labourforce dashboard

### DIFF
--- a/data-raw/internal_data.R
+++ b/data-raw/internal_data.R
@@ -9,7 +9,8 @@ if (requireNamespace("absmapsdata", quietly = T)) {
   qs::qsave(absmapsdata::employment_regions2015, "inst/extdata/employment_regions2015.qs")
 }
 
-dash_data <- get_dash_data(verbose = T)
+dash_data <- get_dash_data(verbose = T) %>%
+                filter(table_no != 'salm')
 stopifnot(inherits(dash_data, "tbl_df"))
 stopifnot(nrow(dash_data) > 800)
 dash_data_updated <- attr(dash_data, "date_updated")


### PR DESCRIPTION
All the tables in dash-data tables are used on labour force dashboard except salm. Salm table is filtered.

Build check showed 3 warnings and 5 notes
e.g. 
> checking Rd files ... NOTE
  prepare_Rd: build_email_content.Rd:9-11: Dropping empty section \value
  prepare_Rd: editEMAIL.Rd:12-14: Dropping empty section \value
  prepare_Rd: editSMS.Rd:12-14: Dropping empty section \value
  prepare_Rd: update_data_and_knit.Rd:9-11: Dropping empty section \value

Checklist
----

All PRs:
* [ ] Rebase to latest dev branch: `git rebase -i dev`
* [ ] Run [styler](https://styler.r-lib.org/) to apply consistent code formatting

New/changed charts:
* [ ] Re-generate `app-cache` files by running the server and clicking to the new charts
  - [ ]  Delete old cache if modifying an existing chart (or changes won't take hold)
* [ ] Menu location: `e.g. Groups > Age`
* [ ] Screenshot attached
