### PR TITLE
UI column breaks

### DIFF
--- a/R/labour_ui.R
+++ b/R/labour_ui.R
@@ -45,7 +45,6 @@ labour_ui <- function(...) {
       shiny::tags$script("$(document).ready(function(){$('a.legalLink').click(function(){$('.sidebar-menu a[data-value=\"legal\"]').trigger('click');})});"),
       shiny::tags$script("$('body').addClass('fixed');"),
       shiny::tags$script("$('.content-wrapper').css('padding-top','100px')"),
-      shiny::tags$style(".tab-content{padding:0;}"),
       shiny::tags$style(".wrapper {background-color: white !important;}"),
       shinydashboard::tabItems(
         shinydashboard::tabItem("overview", page_overviewUI()),

--- a/R/page_aboriginal.R
+++ b/R/page_aboriginal.R
@@ -1,31 +1,38 @@
 page_aboriginalUI <- function(...) {
-  shiny::fluidRow(
-    column_nopad(
-      width = 4,
-      djprshiny::djpr_h1_box("Aboriginal Victorians"),
-      shinydashboard::box(
-        width = 12,
-        style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
-        "This page contains the number of Aboriginal people assisted through the jobactive program. ",
-        "The jobactive program is a Commonwealth program designed to provide services to the majority of job seekers."
+  shiny::fluidPage(
+
+    # header row & table
+    fluidRow(
+
+      column(
+        width = 4,
+        djprshiny::djpr_h1_box("Aboriginal Victorians") %>% fluidRow(),
+        shinydashboard::box(
+          width = 12,
+          style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
+          "This page contains the number of Aboriginal people assisted through the jobactive program. ",
+          "The jobactive program is a Commonwealth program designed to provide services to the majority of job seekers."
+        ) %>% fluidRow()
+      ),
+
+      box(
+        width = 8,
+        uiOutput("table_jobactive_aboriginal") %>%
+          djpr_with_spinner()
       )
     ),
-    box(
-      width = 8,
-      uiOutput("table_jobactive_aboriginal") %>%
-        djpr_with_spinner()
+
+
+    fluidRow(
+      djpr_box_ui("gr_abor_jobactive_sincecovid_line", width = 6),
+      djpr_box_ui("gr_abor_jobactive_bar", width = 6)
     ),
-    djpr_box_ui("gr_abor_jobactive_sincecovid_line", width = 6),
-    djpr_box_ui("gr_abor_jobactive_bar", width = 6),
     height_sync("gr_abor_jobactive_sincecovid_line", "gr_abor_jobactive_bar"),
 
     box(
       width = 12,
       style = "padding:10px;",
       HTML(
-        # "This dashboard is produced by the <b>Strategy and Priority ",
-        # "Projects - Data + Analytics</b> team at the Victorian Department ",
-        # "of Jobs, Precincts and Regions.",
         "The latest data in this ",
         "dashboard is for ", format(data_dates$`6202012`$max, "%B %Y"), '.',
         "We are committed to making our websites accessible to all users.",
@@ -43,7 +50,7 @@ page_aboriginalUI <- function(...) {
           "Copyright | Disclaimer"
         )
       )
-    )
+    ) %>% fluidRow()
   )
 }
 

--- a/R/page_age.R
+++ b/R/page_age.R
@@ -1,34 +1,43 @@
 
 page_ageUI <- function(...) {
-  shiny::fluidRow(
-    column_nopad(
-      width = 4,
-      djpr_h1_box("Age"),
+  shiny::fluidPage(
+
+    fluidRow(
+      column(
+        width = 4,
+        djpr_h1_box("Age") %>% fluidRow(),
+        box(
+          width = 12,
+          style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
+          "ABS Labour force data disaggregated by age can be volatile, and most of this data",
+          " is not seasonally adjusted. DJPR smooths the data ",
+          "by using 12-month rolling averages. While this assists in removing noise",
+          " to focus on the underlying trends, it makes large month-to-month changes ",
+          "in underlying conditions less apparent."
+        )%>% fluidRow()
+      ),
       box(
-        width = 12,
-        style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
-        "ABS Labour force data disaggregated by age can be volatile, and most of this data",
-        " is not seasonally adjusted. DJPR smooths the data ",
-        "by using 12-month rolling averages. While this assists in removing noise",
-        " to focus on the underlying trends, it makes large month-to-month changes ",
-        "in underlying conditions less apparent."
+        width = 8,
+        uiOutput("table_gr_youth_summary") %>%
+          djpr_with_spinner()
       )
     ),
-    box(
-      width = 8,
-      uiOutput("table_gr_youth_summary") %>%
-        djpr_with_spinner()
-    ),
-    djpr_box_ui("gr_yth_emp_sincecovid_line", width = 6, height = "385px"),
-    djpr_box_ui(
-      id = "gr_yth_lfpartrate_vicaus_line",
-      width = 6,
-      height = "385px",
-      date_slider(
+
+    fluidRow(
+      djpr_box_ui("gr_yth_emp_sincecovid_line", width = 6, height = "385px"),
+      djpr_box_ui(
         id = "gr_yth_lfpartrate_vicaus_line",
-        table_no = "6202016"
+        width = 6,
+        height = "385px",
+        date_slider(
+          id = "gr_yth_lfpartrate_vicaus_line",
+          table_no = "6202016"
+        )
       )
     ),
+
+
+    # Focus box
     focus_box(
       title = h2("Labour force status of Victorian youth"),
       inputs = shiny::selectInput("youth_focus",
@@ -90,7 +99,9 @@ page_ageUI <- function(...) {
         ) %>%
           async_no_background()
       )
-    ),
+    ) %>% fluidRow(),
+
+
     djpr_h2_box("Detailed labour force status of Victorian youth"),
     djpr_box_ui("gr_youth_full_part_line",
       width = 12,

--- a/R/page_age.R
+++ b/R/page_age.R
@@ -102,23 +102,23 @@ page_ageUI <- function(...) {
     ) %>% fluidRow(),
 
 
-    djpr_h2_box("Detailed labour force status of Victorian youth"),
+    djpr_h2_box("Detailed labour force status of Victorian youth") %>% fluidRow(),
     djpr_box_ui("gr_youth_full_part_line",
       width = 12,
       date_slider("gr_youth_full_part_line", table_no = "6202016")
-    ),
+    ) %>% fluidRow(),
     djpr_box_ui("gr_youth_eduemp_waterfall",
       width = 12,
-    ),
+    ) %>% fluidRow(),
     djpr_box_ui("gr_yth_mostvuln_line",
       width = 12,
       date_slider("gr_yth_mostvuln_line", table_no = "6202016")
-    ),
-    djpr_h2_box("Youth unemployment rate by region"),
+    ) %>% fluidRow(),
+    djpr_h2_box("Youth unemployment rate by region") %>% fluidRow(),
     box(
       width = 12,
       uiOutput("table_gr_youth_unemp_region") %>% djpr_with_spinner()
-    ),
+    ) %>% fluidRow(),
     focus_box(
       h2(textOutput("title_youth_unemp_emppop_partrate_vic")),
       selectInput("youth_region_focus",
@@ -144,20 +144,23 @@ page_ageUI <- function(...) {
         class = "djpr-caption",
         "Based on Australian Bureau of Statistics data: ABS Labour Force, Detailed (monthly). Note: data is not seasonally adjusted; smoothed using a 12 month rolling average."
       )
-    ),
-    djpr_h2_box("Jobactive caseload for 15-24 year olds (youth)"),
+    ) %>% fluidRow(),
+    djpr_h2_box("Jobactive caseload for 15-24 year olds (youth)") %>% fluidRow(),
     box(
       width = 12,
       uiOutput("table_jobactive_youth") %>% djpr_with_spinner()
-    ),
-    djpr_box_ui("gr_youth_jobactive_bar", width = 12),
-    djpr_h2_box("Jobactive caseload for 50+ (mature age)"),
+    ) %>% fluidRow(),
+    djpr_box_ui("gr_youth_jobactive_bar", width = 12) %>% fluidRow(),
+    djpr_h2_box("Jobactive caseload for 50+ (mature age)") %>% fluidRow(),
     box(
       width = 12,
       uiOutput("table_jobactive_mature_age") %>% djpr_with_spinner()
+    ) %>% fluidRow(),
+
+    fluidRow(
+      djpr_box_ui("gr_age_jobactive_since_covid_line"),
+      djpr_box_ui("gr_mature_age_jobactive_bar")
     ),
-    djpr_box_ui("gr_age_jobactive_since_covid_line"),
-    djpr_box_ui("gr_mature_age_jobactive_bar"),
 
     height_sync(
       "gr_age_jobactive_since_covid_line",
@@ -188,7 +191,7 @@ page_ageUI <- function(...) {
           "Copyright | Disclaimer"
         )
       )
-    )
+    ) %>% fluidRow()
   )
 }
 

--- a/R/page_ausregions.R
+++ b/R/page_ausregions.R
@@ -1,20 +1,20 @@
 
 page_ausregionsUI <- function(...) {
-  fluidRow(
+  fluidPage(
 
     # Unemployment by Australian Regions -------------
-    djprshiny::djpr_h1_box("Australian regions"),
+    djprshiny::djpr_h1_box("Australian regions") %>% fluidRow(),
     shinydashboard::box(
       width = 12,
       style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
       "This section explores labour force indicators in regional and metropolitan areas of Australia."
-    ),
-    djpr_h2_box("Unemployment rate in Australian regional areas"),
+    ) %>% fluidRow(),
+    djpr_h2_box("Unemployment rate in Australian regional areas") %>% fluidRow(),
     box(
       width = 12,
       uiOutput("table_reg_nonmetro_states_unemprate") %>%
         djpr_with_spinner()
-    ),
+    ) %>% fluidRow(),
     focus_box(
       title = h3("Compare regional areas of Australian states"),
       inputs = selectInput(
@@ -34,7 +34,7 @@ page_ausregionsUI <- function(...) {
         djpr_box_ui("reg_regionstates_bar", height = "600px") %>%
           async_no_background()
       )
-    ),
+    )  %>% fluidRow(),
     djpr_box_ui(
       "reg_emp_regionstates_sincecovid_line",
       width = 12,
@@ -51,14 +51,14 @@ page_ausregionsUI <- function(...) {
         ),
         selected = c("Reg. Vic", "Reg. NSW")
       )
-    ),
-    djpr_h2_box("Australian metropolitan areas"),
+    ) %>% fluidRow(),
+    djpr_h2_box("Australian metropolitan areas") %>% fluidRow(),
     box(
       width = 12,
       title = "Unemployment rates in Australian major cities",
       uiOutput("table_reg_metro_states_unemprate") %>%
         djpr_with_spinner()
-    ),
+    ) %>% fluidRow(),
     box(
       width = 12,
       style = "padding:10px;",
@@ -83,7 +83,7 @@ page_ausregionsUI <- function(...) {
           "Copyright | Disclaimer"
         )
       )
-    )
+    ) %>% fluidRow()
   )
 }
 

--- a/R/page_disability.R
+++ b/R/page_disability.R
@@ -1,28 +1,34 @@
 page_disabilityUI <- function(...) {
-  fluidRow(
-    column_nopad(
-      width = 4,
-      djprshiny::djpr_h1_box("People with disability"),
-      shinydashboard::box(
-        width = 12,
-        style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
-        "This page contains the number of people with disability assisted through the jobactive program. ",
-        "More detail by location of residence is available on this page."
+  fluidPage(
+
+    fluidRow(
+      column(
+        width = 4,
+        djprshiny::djpr_h1_box("People with disability") %>% fluidRow(),
+        shinydashboard::box(
+          width = 12,
+          style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
+          "This page contains the number of people with disability assisted through the jobactive program. ",
+          "More detail by location of residence is available on this page."
+        ) %>% fluidRow()
+      ),
+      box(
+        width = 8,
+        uiOutput("table_jobactive_pwd") %>%
+          djpr_with_spinner()
       )
     ),
-    box(
-      width = 8,
-      uiOutput("table_jobactive_pwd") %>%
-        djpr_with_spinner()
-    ),
-    djpr_box_ui(
-      width = 6,
-      id = "gr_pwd_jobact_sincecovid_line",
-      date_slider("gr_pwd_jobact_sincecovid_line", table_no = "jobactive")
-    ),
-    djpr_box_ui(
+
+    fluidRow(
+      djpr_box_ui(
+        width = 6,
+        id = "gr_pwd_jobact_sincecovid_line",
+        date_slider("gr_pwd_jobact_sincecovid_line", table_no = "jobactive")
+      ),
+      djpr_box_ui(
         width = 6,
         id = "gr_pwd_jobactive_bar"
+      )
     ),
 
     height_sync("gr_pwd_jobact_sincecovid_line", "gr_pwd_jobactive_bar"),
@@ -52,7 +58,7 @@ page_disabilityUI <- function(...) {
           "Copyright | Disclaimer"
         )
       )
-    )
+    ) %>% fluidRow()
   )
 }
 

--- a/R/page_indicators.R
+++ b/R/page_indicators.R
@@ -1,26 +1,28 @@
 page_indicatorsUI <- function(...) {
-  fluidRow(
+  fluidPage(
 
-    # No padding column with width = 4
-    column_nopad(
-      width = 4,
-      djprshiny::djpr_h1_box("Indicators"),
-      shinydashboard::box(
-        width = 12,
-        style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
-        "This page includes headline estimates of employment, unemployment, underemployment, participation, and hours worked for Victoria. ",
-        "States comparison for key labour force indicators is also provided."
+    fluidRow(
+      # No padding column with width = 4
+      column(
+        width = 4,
+        djprshiny::djpr_h1_box("Indicators") %>% fluidRow(),
+        shinydashboard::box(
+          width = 12,
+          style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
+          "This page includes headline estimates of employment, unemployment, underemployment, participation, and hours worked for Victoria. ",
+          "States comparison for key labour force indicators is also provided."
+        ) %>% fluidRow()
+      ),
+
+      # htmlOutput("ind_empgrowth_sincecovid_text"),
+
+      box(
+        width = 8,
+        shiny::uiOutput("ind_emp_table") %>%
+          djpr_with_spinner(hide.ui = TRUE)
       )
     ),
-
-    # htmlOutput("ind_empgrowth_sincecovid_text"),
-
-    box(
-      width = 8,
-      shiny::uiOutput("ind_emp_table") %>%
-        djpr_with_spinner(hide.ui = TRUE)
-    ),
-    djpr_h2_box("Employment"),
+    djpr_h2_box("Employment") %>% fluidRow(),
     djpr_box_ui(
       "ind_emppop_state_line",
       width = 12,
@@ -40,7 +42,7 @@ page_indicatorsUI <- function(...) {
           )
         )
       )
-    ),
+    ) %>% fluidRow(),
     djpr_box_ui(
       "ind_empgro_line",
       width = 12,
@@ -54,19 +56,21 @@ page_indicatorsUI <- function(...) {
           )
         )
       )
+    ) %>% fluidRow(),
+
+    fluidRow(
+      djpr_box_ui("ind_gen_full_part_line", width = 6),
+      djpr_box_ui("ind_emp_sincecovid_line", width = 6)
     ),
 
-
-    djpr_box_ui("ind_gen_full_part_line", width = 6),
-    djpr_box_ui("ind_emp_sincecovid_line", width = 6),
     height_sync("ind_gen_full_part_line", "ind_emp_sincecovid_line"),
 
-    djpr_h2_box("Unemployment & underemployment"),
+    djpr_h2_box("Unemployment & underemployment") %>% fluidRow(),
     box(
       width = 12,
       uiOutput("ind_unemp_summary") %>%
         djpr_with_spinner(hide.ui = TRUE)
-    ),
+    ) %>% fluidRow(),
 
     djpr_box_ui(
       "ind_unemprate_line",
@@ -76,8 +80,8 @@ page_indicatorsUI <- function(...) {
         table_no = "6202012",
         value = c(Sys.Date() - years(5), data_dates$`6202012`$max)
       )
-    ),
-    djpr_h2_box("Effective unemployment rate"),
+    ) %>% fluidRow(),
+    djpr_h2_box("Effective unemployment rate") %>%  fluidRow(),
     shinydashboard::box(
       width = 12,
       "People who are employed but have not been able to work any hours do not count ",
@@ -86,16 +90,16 @@ page_indicatorsUI <- function(...) {
       "hours due to economic conditions or 'other reasons', divided by the labour force. ",
       "The unemployment rate is seasonally adjusted, while the effective unemployment rate includes ",
       "a three month average of persons working zero hours for economic or unstated reasons."
-    ),
-    djpr_box_ui("ind_effective_unemprate_line", width = 12),
-    djpr_h2_box("Unemployment rates by state"),
+    ) %>% fluidRow(),
+    djpr_box_ui("ind_effective_unemprate_line", width = 12) %>% fluidRow(),
+    djpr_h2_box("Unemployment rates by state") %>% fluidRow(),
     box(
       width = 12,
       uiOutput("table_ind_unemp_state") %>%
         djpr_with_spinner()
-    ),
+    ) %>% fluidRow(),
 
-    djpr_box_ui("ind_unemp_states_dot", width = 12),
+    djpr_box_ui("ind_unemp_states_dot", width = 12) %>% fluidRow(),
     djpr_box_ui(
       "ind_underut_area",
       width = 12,
@@ -104,9 +108,9 @@ page_indicatorsUI <- function(...) {
         table_no = "6202023",
         value = c(Sys.Date() - years(10), data_dates$`6202023`$max)
       )
-    ),
+    ) %>% fluidRow(),
 
-    djpr_h2_box("Hours worked"),
+    djpr_h2_box("Hours worked") %>% fluidRow(),
     djpr_box_ui(
       "ind_hoursworked_line",
       width = 12,
@@ -115,19 +119,23 @@ page_indicatorsUI <- function(...) {
         table_no = "6202019",
         value = c(as.Date("2000-01-01"), data_dates$`6202019`$max)
       )
+    ) %>% fluidRow(),
+
+    djpr_h2_box("Participation") %>% fluidRow(),
+
+    fluidRow(
+      djpr_box_ui(
+        id = "ind_partrate_line",
+        width = 6,
+        date_slider(
+          id = "ind_partrate_line",
+          table_no = "6202012",
+          value = c(as.Date("2000-01-01"), data_dates$`6202012`$max)
+        )
+      ),
+      djpr_box_ui("ind_partrate_bar", width = 6)
     ),
 
-    djpr_h2_box("Participation"),
-    djpr_box_ui(
-      id = "ind_partrate_line",
-      width = 6,
-      date_slider(
-        id = "ind_partrate_line",
-        table_no = "6202012",
-        value = c(as.Date("2000-01-01"), data_dates$`6202012`$max)
-      )
-    ),
-    djpr_box_ui("ind_partrate_bar", width = 6),
     djpr_box_ui(
       id = "ind_partrate_un_line",
       width = 12,
@@ -136,13 +144,13 @@ page_indicatorsUI <- function(...) {
         table_no = "6202012",
         value = c(Sys.Date() - (10 * 365), data_dates$`6202012`$max)
       )
-    ),
+    ) %>% fluidRow(),
     shinydashboard::box(
       width = 12,
       "A fall in the unemployment rate can mean very different things depending on whether the participation rate is rising - more people have joined the labour force - or falling. ",
       "The chart below shows how the unemployment and participation rates changed over the last month or year, and how that compares to past changes in the Victorian labour market. ",
       "Choose whether you would like to examine monthly, or yearly, changes in the unemployment and participation rates."
-    ),
+    ) %>% fluidRow(),
     djpr_box_ui(
       "ind_partrate_un_scatter",
       width = 12,
@@ -155,7 +163,7 @@ page_indicatorsUI <- function(...) {
           "Yearly" = "year"
         )
       )
-    ),
+    ) %>% fluidRow(),
     box(
       width = 12,
       style = "padding:10px;",
@@ -180,7 +188,7 @@ page_indicatorsUI <- function(...) {
           "Copyright | Disclaimer"
         )
       )
-    )
+    ) %>% fluidRow()
   )
 }
 

--- a/R/page_industries.R
+++ b/R/page_industries.R
@@ -1,30 +1,32 @@
 page_industriesUI <- function(...) {
-  fluidRow(
+  fluidPage(
 
-    # No padding column with width = 4
-    column_nopad(
-      width = 4,
-      djprshiny::djpr_h1_box("Victoria's industries"),
-      shinydashboard::box(
-        width = 12,
-        style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
-        p(
-          "On this page, we explore the employment trends of Victorian industries. ",
-          "The ",
-          shiny::a("ABS", href = "https://www.abs.gov.au/ausstats/abs@.nsf/mf/1292.0"),
-          " classifies businesses into one of 19 broad industry divisions, each of which is further ",
-          " divided into sub-divisions, groups, and classes.",
-          "Note that industries data is not seasonally adjusted and is released quarterly."
-        )
+    fluidRow(
+      # No padding column with width = 4
+      column(
+        width = 4,
+        djprshiny::djpr_h1_box("Victoria's industries") %>% fluidRow(),
+        shinydashboard::box(
+          width = 12,
+          style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
+          p(
+            "On this page, we explore the employment trends of Victorian industries. ",
+            "The ",
+            shiny::a("ABS", href = "https://www.abs.gov.au/ausstats/abs@.nsf/mf/1292.0"),
+            " classifies businesses into one of 19 broad industry divisions, each of which is further ",
+            " divided into sub-divisions, groups, and classes.",
+            "Note that industries data is not seasonally adjusted and is released quarterly."
+          )
+        ) %>% fluidRow()
+      ),
+      box(
+        width = 8,
+        title = h3("Number of people employed by industry"),
+        uiOutput("table_industries_summary") %>%
+          djpr_with_spinner()
       )
     ),
-    box(
-      width = 8,
-      title = h3("Number of people employed by industry"),
-      uiOutput("table_industries_summary") %>%
-        djpr_with_spinner()
-    ),
-    djpr_box_ui("industries_empchange_sincecovid_bar", width = 12),
+    djpr_box_ui("industries_empchange_sincecovid_bar", width = 12) %>% fluidRow(),
     focus_box(
       title = h3("Industry employment trends"),
       inputs = selectInput(
@@ -71,7 +73,7 @@ page_industriesUI <- function(...) {
             djpr_with_spinner()
         )
       )
-    ),
+    ) %>% fluidRow(),
     box(
       width = 12,
       style = "padding:10px;",
@@ -96,7 +98,7 @@ page_industriesUI <- function(...) {
           "Copyright | Disclaimer"
         )
       )
-    )
+    ) %>% fluidRow()
   )
 }
 

--- a/R/page_ltunemp.R
+++ b/R/page_ltunemp.R
@@ -1,36 +1,39 @@
 page_ltunempUI <- function(...) {
-  fluidRow(
+  fluidPage(
 
-    # No padding column with width = 4
-    column_nopad(
-      width = 4,
-      djprshiny::djpr_h1_box("Long-term unemployed"),
-      shinydashboard::box(
-        width = 12,
-        style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
-        "Long-term unemployment is defined as a duration of unemployment of 12 months or more, ",
-        "calculated from the time a person either last worked in any job for two weeks or more, ",
-        "or began actively looking for work (whichever is the more recent). ",
-        "Measuring long-term unemployment is important as it impacts on communities both socially ",
-        "and economically. Compared to short-term unemployed people, those unemployed for longer ",
-        "periods of time can experience higher levels of competition, decreased confidence and motivation."
-      )
-    ),
-    djpr_box_ui(
-      id = "gr_ltunemp_line",
-      width = 8,
-      date_slider(
+    fluidRow(
+      # No padding column with width = 4
+      column(
+        width = 4,
+        djprshiny::djpr_h1_box("Long-term unemployed") %>% fluidRow(),
+        shinydashboard::box(
+          width = 12,
+          style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
+          "Long-term unemployment is defined as a duration of unemployment of 12 months or more, ",
+          "calculated from the time a person either last worked in any job for two weeks or more, ",
+          "or began actively looking for work (whichever is the more recent). ",
+          "Measuring long-term unemployment is important as it impacts on communities both socially ",
+          "and economically. Compared to short-term unemployed people, those unemployed for longer ",
+          "periods of time can experience higher levels of competition, decreased confidence and motivation."
+        ) %>% fluidRow()
+      ),
+      djpr_box_ui(
         id = "gr_ltunemp_line",
-        table_no = "UM2",
-        value = c(as.Date("2000-01-01"), data_dates$`6202012`$max)
+        width = 8,
+        date_slider(
+          id = "gr_ltunemp_line",
+          table_no = "UM2",
+          value = c(as.Date("2000-01-01"), data_dates$`6202012`$max)
+        )
       )
     ),
-    djpr_box_ui("gr_ltunvic_bar", width = 12),
+
+    djpr_box_ui("gr_ltunvic_bar", width = 12) %>% fluidRow(),
     djpr_box_ui(
       "gr_ltunvic_area",
       width = 12,
       date_slider("gr_ltunvic_area", "UM2")
-    ),
+    ) %>% fluidRow(),
     box(
       width = 12,
       style = "padding:10px;",
@@ -55,7 +58,7 @@ page_ltunempUI <- function(...) {
           "Copyright | Disclaimer"
         )
       )
-    )
+    ) %>% fluidRow()
   )
 }
 

--- a/R/page_migration.R
+++ b/R/page_migration.R
@@ -1,22 +1,28 @@
 page_migrationUI <- function(...) {
-  fluidRow(
-    column_nopad(
-      width = 4,
-      djprshiny::djpr_h1_box("Refugees"),
-      shinydashboard::box(
-        width = 12,
-        style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
-        "This page contains the number of refugees assisted through the jobactive program. ",
-        "A comparison of refugees and non-refugees assisted through the program is also available on this page."
+  fluidPage(
+
+    fluidRow(
+      column(
+        width = 4,
+        djprshiny::djpr_h1_box("Refugees") %>% fluidRow(),
+        shinydashboard::box(
+          width = 12,
+          style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
+          "This page contains the number of refugees assisted through the jobactive program. ",
+          "A comparison of refugees and non-refugees assisted through the program is also available on this page."
+        ) %>% fluidRow()
+      ),
+      box(
+        width = 8,
+        uiOutput("table_jobactive_refugees") %>%
+          djpr_with_spinner()
       )
     ),
-    box(
-      width = 8,
-      uiOutput("table_jobactive_refugees") %>%
-        djpr_with_spinner()
+
+    fluidRow(
+      djpr_box_ui("gr_refugee_jobact_sincecovid_line", width = 6),
+      djpr_box_ui("gr_refugee_jobactive_bar", width = 6)
     ),
-    djpr_box_ui("gr_refugee_jobact_sincecovid_line", width = 6),
-    djpr_box_ui("gr_refugee_jobactive_bar", width = 6),
 
     height_sync(
       "gr_refugee_jobact_sincecovid_line",
@@ -47,7 +53,7 @@ page_migrationUI <- function(...) {
           "Copyright | Disclaimer"
         )
       )
-    )
+    ) %>% fluidRow()
   )
 }
 

--- a/R/page_overview.R
+++ b/R/page_overview.R
@@ -1,23 +1,28 @@
 page_overviewUI <- function(...) {
-  shiny::tagList(
+  shiny::fluidPage(
 
-    # No padding column with width = 4
-    column_nopad(
-      width = 4,
+    fluidRow(
+      column(
+        width = 4,
+        fluidRow(
+          djprshiny::djpr_h1_box("DJPR jobs dashboard")
+        ),
+        fluidRow(
+          shinydashboard::box(
+            width = 12,
+            style = "padding: 15px;font-size: 20px;background: #C0E4B5;",
+            "The DJPR Jobs Dashboard explores information on Victorian employment and job seekers. Use the sidebar to navigate through information on various demographics such as regions, age, sex and industry."
+          )
+        )
+      ),
 
-      djprshiny::djpr_h1_box("DJPR jobs dashboard"),
-
-      shinydashboard::box(
-        width = 12,
-        style = "padding: 15px;font-size: 20px;background: #C0E4B5;",
-        "The DJPR Jobs Dashboard explores information on Victorian employment and job seekers. Use the sidebar to navigate through information on various demographics such as regions, age, sex and industry."
+      box(
+        width = 8,
+        shiny::uiOutput("main_table", height = "800px") %>%
+          djpr_with_spinner(proxy.height = "800px")
       )
     ),
-    box(
-      width = 8,
-      shiny::uiOutput("main_table", height = "800px") %>%
-        djpr_with_spinner(proxy.height = "800px")
-    ),
+
     box(
       width = 12,
       style = "padding:10px;",
@@ -42,7 +47,8 @@ page_overviewUI <- function(...) {
           "Copyright | Disclaimer"
           )
       )
-    )
+    ) %>%
+      fluidRow()
   )
 }
 

--- a/R/page_sex.R
+++ b/R/page_sex.R
@@ -1,24 +1,28 @@
 page_sexUI <- function(...) {
-  fluidRow(
+  fluidPage(
 
-    # No padding column with width = 4
-    column_nopad(
-      width = 4,
-      djprshiny::djpr_h1_box("Sex"),
-      shinydashboard::box(
-        width = 12,
-        style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
-        "This page provides key labour force indicators by sex. ",
-        "It also contains information on females assisted through the jobactive program."
+    fluidRow(
+
+      # No padding column with width = 4
+      column_nopad(
+        width = 4,
+        djprshiny::djpr_h1_box("Sex") %>% fluidRow(),
+        shinydashboard::box(
+          width = 12,
+          style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
+          "This page provides key labour force indicators by sex. ",
+          "It also contains information on females assisted through the jobactive program."
+        ) %>% fluidRow()
+      ),
+
+      box(
+        width = 8,
+        uiOutput("table_gr_sex") %>%
+          djpr_with_spinner()
       )
     ),
-    box(
-      width = 8,
-      uiOutput("table_gr_sex") %>%
-        djpr_with_spinner()
-    ),
-    djpr_h2_box("Labour force status by sex"),
-    djpr_box_ui(width = 12, "gr_gen_emp_bar"),
+    djpr_h2_box("Labour force status by sex")  %>% fluidRow(),
+    djpr_box_ui(width = 12, "gr_gen_emp_bar") %>% fluidRow(),
     djpr_box_ui(
       width = 12,
       id = "gr_full_part_line",
@@ -27,8 +31,8 @@ page_sexUI <- function(...) {
         table_no = "6202012",
         value = c(Sys.Date() - (365.25 * 5), data_dates$`6202012`$max)
       )
-    ),
-    djpr_h2_box("Unemployment by sex"),
+    ) %>% fluidRow(),
+    djpr_h2_box("Unemployment by sex") %>% fluidRow(),
     djpr_box_ui(
       width = 12,
       id = "gr_gen_unemp_line",
@@ -37,8 +41,8 @@ page_sexUI <- function(...) {
         table_no = "6202012",
         value = c(Sys.Date() - (365.25 * 10), data_dates$`6202012`$max)
       )
-    ),
-    djpr_h2_box("Employment to population ratio by sex"),
+    ) %>% fluidRow(),
+    djpr_h2_box("Employment to population ratio by sex") %>% fluidRow(),
     djpr_box_ui(
       width = 12,
       "gr_gen_emppopratio_line",
@@ -47,25 +51,25 @@ page_sexUI <- function(...) {
         table_no = "6202012",
         value = c(Sys.Date() - (365.25 * 10), data_dates$`6202012`$max)
       )
-    ),
-    djpr_h2_box("Participation rate by sex"),
+    ) %>% fluidRow(),
+    djpr_h2_box("Participation rate by sex") %>% fluidRow(),
     djpr_box_ui(
       width = 12,
       "gr_gen_partrate_line",
       date_slider("gr_gen_partrate_line", table_no = "6202012")
-    ),
-    djpr_h2_box("Jobactive caseload by sex"),
+    ) %>% fluidRow(),
+    djpr_h2_box("Jobactive caseload by sex") %>% fluidRow(),
     box(
       width = 12,
       uiOutput("table_jobactive_female") %>%
         djpr_with_spinner()
-    ),
+    ) %>% fluidRow(),
     djpr_box_ui(
       width = 12,
       id = "gr_female_jobact_sincecovid_line",
       date_slider("gr_female_jobact_sincecovid_line", table_no = "jobactive")
-    ),
-    djpr_box_ui(width = 12, "gr_female_jobactive_bar"),
+    ) %>% fluidRow(),
+    djpr_box_ui(width = 12, "gr_female_jobactive_bar") %>% fluidRow(),
     box(
       width = 12,
       style = "padding:10px;",
@@ -90,7 +94,7 @@ page_sexUI <- function(...) {
           "Copyright | Disclaimer"
         )
       )
-    )
+    ) %>% fluidRow()
   )
 }
 

--- a/R/page_vicregions.R
+++ b/R/page_vicregions.R
@@ -1,15 +1,14 @@
 page_vicregionsUI <- function(...) {
-  fluidRow(
-
+  fluidPage(
 
     # Unemployment by region -----
-    djprshiny::djpr_h1_box("Victorian regions"),
+    djprshiny::djpr_h1_box("Victorian regions") %>% fluidRow(),
     shinydashboard::box(
       width = 12,
       style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
       "Victoria contains a range of diverse regions, both within Greater Melbourne and outside the metropolitan area. Below we explore the regional differences in historical and current labour force status within Victoria. "
-    ),
-    djpr_h2_box("Labour force status by region"),
+    ) %>% fluidRow(),
+    djpr_h2_box("Labour force status by region") %>% fluidRow(),
     focus_box(
       title = tagList(
         h3(textOutput("title_reg_unemp_emppop_partrate_vic"), style = "color:#FFFFFF"),
@@ -39,7 +38,7 @@ page_vicregionsUI <- function(...) {
           plotOutput("reg_unemp_emppop_partrate_bar") %>%
             djpr_with_spinner()
         )
-      ),
+      ) %>% fluidRow(),
       div(
         class = "djpr-caption",
         "Based on Australian Bureau of Statistics data: ABS Labour Force, Detailed (monthly). Note: data is not seasonally adjusted; smoothed using a 3 month rolling average."
@@ -73,8 +72,8 @@ page_vicregionsUI <- function(...) {
           )
         )
       )
-    ),
-    djpr_h3_box("Unemployment rate variations across Victoria"),
+    ) %>% fluidRow(),
+    djpr_h3_box("Unemployment rate variations across Victoria") %>% fluidRow(),
     box(
       width = 12,
       style = "padding: 15px;font-size: 15px;background: #C0E4B5;",
@@ -85,7 +84,7 @@ page_vicregionsUI <- function(...) {
       "difference between minimum and maximum) of unemployment rates over time",
       "in different regions in Victoria. The breakdown of regions is by ",
       shiny::a("SA4.", href = "https://www.abs.gov.au/statistics/standards/australian-statistical-geography-standard-asgs-edition-3/jul2021-jun2026/main-structure-and-greater-capital-city-statistical-areas/statistical-area-level-4")
-    ),
+    ) %>% fluidRow(),
     djpr_box_ui(
       id = "reg_unemprate_dispersion",
       width = 12,
@@ -112,11 +111,11 @@ page_vicregionsUI <- function(...) {
           )
         )
       )
-    ),
+    ) %>% fluidRow(),
 
 
     # Regional Vic vs Greater Melb -----
-    djpr_h2_box("Regional Victoria and Greater Melbourne"),
+    djpr_h2_box("Regional Victoria and Greater Melbourne") %>% fluidRow(),
     djpr_box_ui(
       id = "reg_melvic_line",
       width = 12,
@@ -125,13 +124,13 @@ page_vicregionsUI <- function(...) {
         table_no = "6291002",
         value = c(as.Date("2014-11-01"), data_dates$`6291002`$max)
       )
-    ),
-    djpr_box_ui("reg_emp_regions_sincecovid_line", width = 12),
+    ) %>% fluidRow(),
+    djpr_box_ui("reg_emp_regions_sincecovid_line", width = 12) %>% fluidRow(),
 
 
 
     # Victorian regions focus box ------
-    djpr_h2_box("Regional Victoria"),
+    djpr_h2_box("Regional Victoria") %>% fluidRow(),
     # Box for regional focus
     focus_box(
       title = h3("Compare regions of Victoria"),
@@ -175,7 +174,9 @@ page_vicregionsUI <- function(...) {
             djpr_with_spinner(proxy.height = "30px"),
           plotOutput("reg_sa4unemp_cf_broadregion", height = 300) %>%
             djpr_with_spinner()
-        ),
+        )
+      ),
+      fluidRow(
         column(
           12,
           uiOutput("table_region_focus") %>%
@@ -183,7 +184,7 @@ page_vicregionsUI <- function(...) {
         )
       )
     ),
-    djpr_h2_box("Victorian jobactive caseload by employment region"),
+    djpr_h2_box("Victorian jobactive caseload by employment region") %>% fluidRow(),
     focus_box(
       title = h3(uiOutput("title_reg_jobactive_vic")),
       inputs = NULL,
@@ -200,8 +201,13 @@ page_vicregionsUI <- function(...) {
             djpr_with_spinner()
         )
       ),
-      uiOutput("table_jobactive_regions") %>%
-        djpr_with_spinner()
+      fluidRow(
+        column(
+          12,
+          uiOutput("table_jobactive_regions") %>%
+            djpr_with_spinner()
+        )
+      )
     ),
     box(
       width = 12,
@@ -227,7 +233,7 @@ page_vicregionsUI <- function(...) {
           "Copyright | Disclaimer"
         )
       )
-    )
+    ) %>% fluidRow()
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -62,7 +62,7 @@ state_checkbox <- function(
 box <- function(..., width = 6, title = NULL, footer = NULL, height = NULL) {
   stopifnot(width %in% 1:12)
 
-  shiny::column(
+  column(
     width,
     # class = paste0("col-sm-", width),
     shiny::div(
@@ -76,8 +76,15 @@ box <- function(..., width = 6, title = NULL, footer = NULL, height = NULL) {
 }
 
 
+# Column shim
+column <- function(width, ...){
+  colClass <- paste0("col-xl-", width)
+  shiny::div(class = colClass, ...)
+}
+
+
 column_nopad <- function(width = 6, ...) {
-  shiny::column(width = width, ...) %>%
+  column(width = width, ...) %>%
     shiny::tagAppendAttributes(style = "padding:0px;")
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,6 +76,21 @@ box <- function(..., width = 6, title = NULL, footer = NULL, height = NULL) {
 }
 
 
+# djpr_box_ui shim
+djpr_box_ui <- function(...){
+  ui      <- djprshiny::djpr_box_ui(...)
+  colsize <- ui %>%
+    shiny::tagGetAttribute("class") %>%
+    substr(., 8, nchar(.))
+
+  ui$attribs$class <- paste0("col-xl-", colsize)
+  return(ui)
+}
+
+
+
+
+
 # Column shim
 column <- function(width, ...){
   colClass <- paste0("col-xl-", width)


### PR DESCRIPTION
Hey @mrjoh3. This branch changes the ui from bootstrap grid sm columns to xl columns. Main difference is that it will break into one row at a wider screen width than before. Some content was outside the box bounds and did not look nice but this should fix it. Also, this layout should work with the full-width iframe implementation or the centered content iframe (collapsing to one row). Note that `shiny::column` only supports bootstap `col-sm` by default so I've made some shims in the util file to keep the same code throughout the app while updating to xl columns. 

Oh and one other thing - I tried to fix nested columns with some clunky CSS previously but it turns out fluid rows automatically reduce margin by 15px when nested so I've drenched the app in `%>% fluidRow()`
